### PR TITLE
Fix: Resolve timestamp migration error by switching to dateTime

### DIFF
--- a/database/migrations/2025_07_09_084903_create_eventi_table.php
+++ b/database/migrations/2025_07_09_084903_create_eventi_table.php
@@ -17,8 +17,8 @@ return new class extends Migration
             $table->text('description')->nullable();
             $table->foreignId('created_by')->constrained('users')->onDelete('cascade');
             $table->text('note')->nullable();
-            $table->timestamp('start_time');
-            $table->timestamp('end_time');
+            $table->dateTime('start_time');
+            $table->dateTime('end_time');
             $table->string('timezone')->default('UTC');
             $table->foreignId('category_id')->nullable()->constrained('categorie_evento')->nullOnDelete();
             $table->foreignId('recurrence_id')->nullable()->constrained('ricorrenze_eventi')->nullOnDelete();


### PR DESCRIPTION
The description provides the context, explains the problem, details the solution, and notes any impact.

Markdown

## Summary

Switches the `start_time` and `end_time` columns in the `eventi_table` migration from the `timestamp` type to the **`dateTime`** type.

---

## The Problem

The original use of the **`timestamp`** column type without making the columns nullable (`->nullable()`) or providing an explicit default (`->default(...)`) caused a migration failure on MySQL databases. This is due to MySQL's strict requirement for a default value on non-nullable `timestamp` columns.

## The Solution

By replacing:
```php
$table->timestamp('start_time');
$table->timestamp('end_time');
```
with:

PHP
```
$table->dateTime('start_time');
$table->dateTime('end_time');
```
we bypass this database-level restriction. The dateTime type provides the necessary date and time storage without the strict default constraints of the timestamp type, allowing the migration to run successfully.