### PR TITLE
Impedire il riutilizzo della password corrente durante il cambio password

### DIFF
--- a/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/Http/Controllers/Settings/PasswordController.php
@@ -29,18 +29,18 @@ class PasswordController extends Controller
      */
     public function update(Request $request): RedirectResponse
     {
-    
         $validated = $request->validate([
             'current_password' => ['required', 'current_password'],
-            'password' => ['required', Password::defaults(), 'confirmed'],
+            'password' => [
+                'required', 
+                Password::defaults(), 
+                'confirmed', 
+                'different:current_password' // Validazione nativa
+            ],
+        ], [
+            // Messaggio personalizzato per migliorare la UX
+            'password.different' => 'La nuova password deve essere diversa dalla password attuale.',
         ]);
-
-             //  Controllo password identica
-    if (Hash::check($validated['password'], $request->user()->password)) {
-        return back()->withErrors([
-            'password' => 'La nuova password deve essere diversa dalla password attuale.',
-        ]);
-    }
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),

--- a/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/Http/Controllers/Settings/PasswordController.php
@@ -29,10 +29,18 @@ class PasswordController extends Controller
      */
     public function update(Request $request): RedirectResponse
     {
+    
         $validated = $request->validate([
             'current_password' => ['required', 'current_password'],
             'password' => ['required', Password::defaults(), 'confirmed'],
         ]);
+
+             //  Controllo password identica
+    if (Hash::check($validated['password'], $request->user()->password)) {
+        return back()->withErrors([
+            'password' => 'La nuova password deve essere diversa dalla password attuale.',
+        ]);
+    }
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),


### PR DESCRIPTION
### Sommario

Questa PR migliora la sicurezza del cambio password impedendo agli utenti di impostare come nuova password lo stesso valore della password corrente.

In precedenza l'applicazione consentiva il riutilizzo della password: l'hash veniva aggiornato, ma il segreto rimaneva invariato, rendendo inefficace la rotazione della password.

---

### Problema

Consentire il riutilizzo della password durante il cambio password:

- Indebolisce le policy di password rotation
- Non mitiga scenari di compromissione delle credenziali
- Genera un falso senso di sicurezza, poiché viene registrato un evento di "password cambiata" senza che il segreto venga realmente modificato

Questo comportamento non è allineato alle raccomandazioni OWASP ASVS sulla prevenzione del riutilizzo delle password.

---

### Soluzione

- Aggiunto un controllo server-side per verificare che la nuova password sia diversa da quella attuale
- Restituito un errore di validazione se viene rilevato il riutilizzo della password

---

### Impatto sulla sicurezza

- Migliora la mitigazione post-compromissione
- Rende effettiva la password rotation
- Allinea il comportamento dell’applicazione alle linee guida OWASP ASVS



---

### Test eseguiti

- Cambio password riuscito con una nuova password diversa
- Cambio password bloccato se la nuova password coincide con quella attuale
- Cambio password bloccato se la password attuale è errata

---

### Riferimenti

- OWASP ASVS v4 – V2.1.7, V2.1.9
